### PR TITLE
Add rotating log config

### DIFF
--- a/desktop_app/logging_config.py
+++ b/desktop_app/logging_config.py
@@ -1,0 +1,39 @@
+"""Central logging configuration."""
+
+from __future__ import annotations
+
+import logging
+from logging.config import dictConfig
+from pathlib import Path
+
+
+def setup_logging() -> None:
+    """Configure the application root logger."""
+    root_logger = logging.getLogger()
+    if root_logger.handlers:
+        return
+
+    log_file = Path(__file__).resolve().parent / "logs" / "caelus.log"
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+
+    config = {
+        "version": 1,
+        "formatters": {
+            "default": {
+                "format": "%(asctime)s — %(levelname)s — %(name)s — %(message)s"
+            }
+        },
+        "handlers": {
+            "file": {
+                "class": "logging.handlers.RotatingFileHandler",
+                "filename": str(log_file),
+                "maxBytes": 10_485_760,
+                "backupCount": 3,
+                "formatter": "default",
+            }
+        },
+        "root": {"level": "INFO", "handlers": ["file"]},
+    }
+
+    dictConfig(config)
+

--- a/desktop_app/services/export_service.py
+++ b/desktop_app/services/export_service.py
@@ -10,19 +10,13 @@ import sys
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
+from ..logging_config import setup_logging
+
 import openai
 
 
-LOG_FILE = Path(__file__).resolve().parents[1] / "logs" / "caelus.log"
-LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+setup_logging()
 _LOGGER = logging.getLogger(__name__)
-if not _LOGGER.handlers:
-    handler = logging.FileHandler(LOG_FILE)
-    handler.setFormatter(
-        logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
-    )
-    _LOGGER.addHandler(handler)
-    _LOGGER.setLevel(logging.INFO)
 
 
 class ExportService:

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,24 @@
+import logging
+from logging.handlers import RotatingFileHandler
+
+from desktop_app.logging_config import setup_logging
+
+
+def test_setup_logging():
+    root = logging.getLogger()
+    original_handlers = root.handlers[:]
+    for h in original_handlers:
+        root.removeHandler(h)
+    try:
+        setup_logging()
+        handlers = [h for h in root.handlers if isinstance(h, RotatingFileHandler)]
+        assert handlers, "RotatingFileHandler not configured"
+        handler = handlers[0]
+        assert handler.maxBytes == 10_485_760
+        assert handler.backupCount == 3
+        assert handler.baseFilename.endswith("desktop_app/logs/caelus.log")
+    finally:
+        for h in root.handlers:
+            root.removeHandler(h)
+        for h in original_handlers:
+            root.addHandler(h)


### PR DESCRIPTION
## Summary
- centralize logging in `logging_config.py`
- use the rotating log configuration in `ExportService`
- add tests for the new logging configuration

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b7cf869d8832f925cc92799ba877f