### PR TITLE
Add AgentGenerator scaffolding utility

### DIFF
--- a/generator/__init__.py
+++ b/generator/__init__.py
@@ -1,6 +1,9 @@
+from .agent_generator import AgentGenerator
+
+
 class Agent:
     """Agent Generator agent."""
 
-    def run(self):
+    def run(self) -> None:
         """Run the agent."""
         raise NotImplementedError()

--- a/generator/agent_generator.py
+++ b/generator/agent_generator.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Any
+
+from cookiecutter.main import cookiecutter
+
+
+class AgentGenerator:
+    """Utility for generating new agent packages."""
+
+    def run(
+        self, template_name: str, prompts: Dict[str, Any], *, output_dir: str | Path | None = None
+    ) -> str:
+        """Cookiecutter drive that scaffolds new agent packages and basic tests.
+
+        Parameters
+        ----------
+        template_name:
+            Name of the template directory inside the repository ``templates``
+            folder.
+        prompts:
+            Mapping of cookiecutter variables to values.
+
+        output_dir:
+            Directory where the generated package should be created. Defaults to
+            the current working directory.
+
+        Returns
+        -------
+        str
+            Absolute path to the generated folder.
+        """
+        template_path = Path(__file__).resolve().parents[1] / "templates" / template_name
+        output_path = cookiecutter(
+            str(template_path),
+            no_input=True,
+            extra_context=prompts,
+            output_dir=str(output_dir) if output_dir else ".",
+        )
+        return str(Path(output_path).resolve())

--- a/generator/tests/test_agent_generator_run.py
+++ b/generator/tests/test_agent_generator_run.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from generator.agent_generator import AgentGenerator
+
+
+def test_agent_generator_run(tmp_path):
+    gen = AgentGenerator()
+    folder = gen.run(
+        "caelus-agent",
+        {"agent_name": "Foo Agent", "agent_slug": "foo_agent"},
+        output_dir=tmp_path,
+    )
+
+    generated = Path(folder)
+    assert generated.exists()
+    assert generated.name == "foo_agent"
+    assert (generated / "agent.py").exists()
+    assert (generated / "tests" / "test_basic.py").exists()
+    assert generated.parent == tmp_path


### PR DESCRIPTION
## Summary
- implement `AgentGenerator.run` for cookiecutter-based scaffolding
- expose `AgentGenerator` from package
- add unit test for generator

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b8c54bbbc832f9ca99478d90315dd