### PR TITLE
Update PyInstaller spec data settings

### DIFF
--- a/CaelusIntegratedAgents.spec
+++ b/CaelusIntegratedAgents.spec
@@ -28,6 +28,7 @@ exe = EXE(
     pyz,
     a.scripts,
     a.binaries,
+    a.zipfiles,
     a.datas,
     [],
     name='CaelusIntegratedAgents',

--- a/desktop_app/resources/installer.spec
+++ b/desktop_app/resources/installer.spec
@@ -28,6 +28,7 @@ exe = EXE(
     pyz,
     a.scripts,
     a.binaries,
+    a.zipfiles,
     a.datas,
     [],
     name='CaelusIntegratedAgents',


### PR DESCRIPTION
## Summary
- ensure PyInstaller bundles resource files by including `a.zipfiles`
- keep windowed, one-file configuration for both specs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: docx, cookiecutter, openai, apscheduler)*

------
https://chatgpt.com/codex/tasks/task_e_684c24112644832faf5d0a51b34b3fcd