### PR TITLE
Use slugify for agent slugs

### DIFF
--- a/generator/agent.py
+++ b/generator/agent.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import logging
-import re
 from pathlib import Path
+
+from slugify import slugify
 
 from cookiecutter.main import cookiecutter
 
@@ -28,7 +29,7 @@ class Agent:
 
         logger = logging.getLogger(__name__)
 
-        slug = re.sub(r"[^0-9a-zA-Z]+", "_", agent_name).strip("_").lower()
+        slug = slugify(agent_name)
         template = Path(__file__).resolve().parents[1] / "templates" / "caelus-agent"
         out_path = cookiecutter(
             str(template),

--- a/generator/tests/test_agent_generator_run.py
+++ b/generator/tests/test_agent_generator_run.py
@@ -7,13 +7,13 @@ def test_agent_generator_run(tmp_path):
     gen = AgentGenerator()
     folder = gen.run(
         "caelus-agent",
-        {"agent_name": "Foo Agent", "agent_slug": "foo_agent"},
+        {"agent_name": "Foo Agent", "agent_slug": "foo-agent"},
         output_dir=tmp_path,
     )
 
     generated = Path(folder)
     assert generated.exists()
-    assert generated.name == "foo_agent"
+    assert generated.name == "foo-agent"
     assert (generated / "agent.py").exists()
     assert (generated / "tests" / "test_basic.py").exists()
     assert generated.parent == tmp_path

--- a/generator/tests/test_basic.py
+++ b/generator/tests/test_basic.py
@@ -9,6 +9,6 @@ def test_run_generates_package(tmp_path, monkeypatch):
     folder = Path(agent.run("My Agent", "demo"))
 
     assert folder.exists()
-    assert folder.name == "my_agent"
+    assert folder.name == "my-agent"
     assert (folder / "agent.py").exists()
     assert (folder / "tests" / "test_basic.py").exists()

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ psycopg2-binary==2.9.10
 
 pytest==8.1.1
 apscheduler==3.11.0
+python-slugify==8.0.1


### PR DESCRIPTION
## Summary
- switch to `python-slugify` for creating slugs when generating agent packages
- update tests to expect hyphenated slugs
- add python-slugify to requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c68ba3bdc832fbb8ef96f4cff038a