### PR TITLE
Use YAML for desktop logging config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,8 @@ sudo apt-get install -y libegl1 libxkbcommon-x11-0
 ```
 
 After building, run the executable from the `dist/` directory.
+
+### Custom Logging Configuration
+
+Set the `CAELUS_LOGGING_CONFIG` environment variable to the path of a YAML file
+to override the default logging setup.

--- a/desktop_app/logging_config.py
+++ b/desktop_app/logging_config.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import logging
 from logging.config import dictConfig
 from pathlib import Path
+import yaml
 
 
-def setup_logging() -> None:
+def setup_logging(yaml_path: str | Path | None = None) -> None:
     """Configure the application root logger."""
     root_logger = logging.getLogger()
     if root_logger.handlers:
@@ -16,24 +17,37 @@ def setup_logging() -> None:
     log_file = Path(__file__).resolve().parent / "logs" / "caelus.log"
     log_file.parent.mkdir(parents=True, exist_ok=True)
 
-    config = {
-        "version": 1,
-        "formatters": {
-            "default": {
-                "format": "%(asctime)s — %(levelname)s — %(name)s — %(message)s"
-            }
-        },
-        "handlers": {
-            "file": {
-                "class": "logging.handlers.RotatingFileHandler",
-                "filename": str(log_file),
-                "maxBytes": 10_485_760,
-                "backupCount": 3,
-                "formatter": "default",
-            }
-        },
-        "root": {"level": "INFO", "handlers": ["file"]},
-    }
+    if yaml_path is None:
+        yaml_path = Path(__file__).resolve().parent / "resources" / "logging.yaml"
+    yaml_path = Path(yaml_path)
+
+    if yaml_path.exists():
+        with open(yaml_path, "r", encoding="utf-8") as fh:
+            config = yaml.safe_load(fh)
+        # Replace relative filename with absolute path
+        handlers = config.get("handlers", {})
+        for handler in handlers.values():
+            if handler.get("class") == "logging.handlers.RotatingFileHandler":
+                handler["filename"] = str(log_file)
+    else:
+        config = {
+            "version": 1,
+            "formatters": {
+                "default": {
+                    "format": "%(asctime)s — %(levelname)s — %(name)s — %(message)s"
+                }
+            },
+            "handlers": {
+                "file": {
+                    "class": "logging.handlers.RotatingFileHandler",
+                    "filename": str(log_file),
+                    "maxBytes": 10_485_760,
+                    "backupCount": 3,
+                    "formatter": "default",
+                }
+            },
+            "root": {"level": "INFO", "handlers": ["file"]},
+        }
 
     dictConfig(config)
 

--- a/desktop_app/logging_config.py
+++ b/desktop_app/logging_config.py
@@ -3,13 +3,22 @@
 from __future__ import annotations
 
 import logging
+import os
 from logging.config import dictConfig
 from pathlib import Path
 import yaml
 
 
 def setup_logging(yaml_path: str | Path | None = None) -> None:
-    """Configure the application root logger."""
+    """Configure the application root logger.
+
+    Parameters
+    ----------
+    yaml_path:
+        Optional path to a YAML logging configuration file. If not provided,
+        the function looks for a ``CAELUS_LOGGING_CONFIG`` environment variable
+        and falls back to ``desktop_app/resources/logging.yaml``.
+    """
     root_logger = logging.getLogger()
     if root_logger.handlers:
         return
@@ -18,7 +27,11 @@ def setup_logging(yaml_path: str | Path | None = None) -> None:
     log_file.parent.mkdir(parents=True, exist_ok=True)
 
     if yaml_path is None:
-        yaml_path = Path(__file__).resolve().parent / "resources" / "logging.yaml"
+        env_path = os.environ.get("CAELUS_LOGGING_CONFIG")
+        if env_path:
+            yaml_path = Path(env_path)
+        else:
+            yaml_path = Path(__file__).resolve().parent / "resources" / "logging.yaml"
     yaml_path = Path(yaml_path)
 
     if yaml_path.exists():

--- a/desktop_app/resources/logging.yaml
+++ b/desktop_app/resources/logging.yaml
@@ -1,11 +1,14 @@
 version: 1
 formatters:
-  simple:
-    format: '%(levelname)s:%(name)s:%(message)s'
+  default:
+    format: '%(asctime)s — %(levelname)s — %(name)s — %(message)s'
 handlers:
-  console:
-    class: logging.StreamHandler
-    formatter: simple
+  file:
+    class: logging.handlers.RotatingFileHandler
+    filename: desktop_app/logs/caelus.log
+    maxBytes: 10485760  # 10 MB
+    backupCount: 3
+    formatter: default
 root:
   level: INFO
-  handlers: [console]
+  handlers: [file]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@ cookiecutter==2.6.0
 pdfplumber==0.11.7
 psycopg2-binary==2.9.10
 
+pyyaml==6.0.2
+
 pytest==8.1.1
 apscheduler==3.11.0
 python-slugify==8.0.1

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -22,3 +22,42 @@ def test_setup_logging():
             root.removeHandler(h)
         for h in original_handlers:
             root.addHandler(h)
+
+
+def test_setup_logging_custom_yaml(tmp_path, monkeypatch):
+    root = logging.getLogger()
+    original_handlers = root.handlers[:]
+    for h in original_handlers:
+        root.removeHandler(h)
+
+    yaml_file = tmp_path / "cfg.yaml"
+    yaml_file.write_text(
+        """
+version: 1
+handlers:
+  file:
+    class: logging.handlers.RotatingFileHandler
+    filename: test.log
+    maxBytes: 123
+    backupCount: 1
+    formatter: default
+formatters:
+  default:
+    format: '%(message)s'
+root:
+  level: INFO
+  handlers: [file]
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CAELUS_LOGGING_CONFIG", str(yaml_file))
+    try:
+        setup_logging()
+        handler = next(h for h in root.handlers if isinstance(h, RotatingFileHandler))
+        assert handler.maxBytes == 123
+        assert handler.backupCount == 1
+    finally:
+        for h in root.handlers:
+            root.removeHandler(h)
+        for h in original_handlers:
+            root.addHandler(h)


### PR DESCRIPTION
## Summary
- load desktop logging config from a YAML file
- expand the YAML logging config to include file handler details
- add PyYAML to requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c6c6ef784832facd4f73859ba39f2