### PR TITLE
Update PyInstaller spec for portability

### DIFF
--- a/CaelusIntegratedAgents.spec
+++ b/CaelusIntegratedAgents.spec
@@ -1,47 +1,54 @@
 # -*- mode: python ; coding: utf-8 -*-
+"""
+PyInstaller spec for the Caelus desktop app.
+This version collects binaries only if they exist on the build host so the
+build works on Windows, macOS and Linux.
+"""
+from pathlib import Path
+from PyInstaller.utils.hooks import collect_dynamic_libs
 
 block_cipher = None
 
+
+def _safe_collect(package, dest):
+    """Collect binaries from *package* but only keep those that exist."""
+    out = []
+    for src, _ in collect_dynamic_libs(package, dest):
+        if Path(src).is_file():
+            out.append((src, dest))
+    return out
+
+
+binaries = _safe_collect("PySide6", "PySide6")
+
 a = Analysis(
-    ['desktop_app/app.py'],
+    ["desktop_app/main.py"],
     pathex=[],
-    binaries=[
-        ('/lib/x86_64-linux-gnu/libEGL.so.1', 'lib'),
-        ('/lib/x86_64-linux-gnu/libxkbcommon-x11.so.0', 'lib'),
-    ],
+    binaries=binaries,
     datas=[
-        ('desktop_app/resources/icons', 'icons'),
-        ('desktop_app/resources/logging.yaml', '.'),
-        ('.env', '.'),
+        ("desktop_app/resources/icons", "icons"),
+        ("desktop_app/resources/logging.yaml", "."),
     ],
-    hiddenimports=['PySide6.QtCore', 'PySide6.QtGui', 'PySide6.QtWidgets'],
+    hiddenimports=["PySide6.QtCore", "PySide6.QtGui", "PySide6.QtWidgets"],
     hookspath=[],
-    hooksconfig={},
     runtime_hooks=[],
-    excludes=[],
-    noarchive=False,
-    optimize=0,
+    cipher=block_cipher,
 )
 pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
-
 exe = EXE(
     pyz,
     a.scripts,
+    exclude_binaries=True,
+    name="CaelusIntegratedAgents",
+    console=False,
+    icon=None,
+)
+coll = COLLECT(
+    exe,
     a.binaries,
     a.zipfiles,
     a.datas,
-    [],
-    name='CaelusIntegratedAgents',
-    debug=False,
-    bootloader_ignore_signals=False,
     strip=False,
     upx=True,
-    upx_exclude=[],
-    runtime_tmpdir=None,
-    console=False,
-    disable_windowed_traceback=False,
-    argv_emulation=False,
-    target_arch=None,
-    codesign_identity=None,
-    entitlements_file=None,
+    name="CaelusIntegratedAgents",
 )


### PR DESCRIPTION
## Summary
- modernize `CaelusIntegratedAgents.spec`
  - collect PySide6 binaries only if they exist on the build host
  - use `desktop_app/main.py` as the entry point
  - include a COLLECT stage

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c762ae864832f816773157a2fb4f9