### PR TITLE
Implement global runtime stats for dashboard

### DIFF
--- a/desktop_app/app_state.py
+++ b/desktop_app/app_state.py
@@ -1,0 +1,16 @@
+from PySide6.QtCore import QObject, Signal
+
+class ApplicationState(QObject):
+    status_changed = Signal(str, str)   # category, message
+
+    # runtime stats object
+    stats = {
+        "exports": 0,
+        "active_agents": 0,
+    }
+
+    def update_stat(self, key: str, delta: int = 1):
+        self.stats[key] = self.stats.get(key, 0) + delta
+        self.status_changed.emit("stats", str(self.stats))
+
+STATE = ApplicationState()

--- a/expected_files.json
+++ b/expected_files.json
@@ -616,6 +616,7 @@
   "awesome-llm-apps-main/voice_ai_agents/voice_rag_openaisdk/rag_voice.py",
   "awesome-llm-apps-main/voice_ai_agents/voice_rag_openaisdk/requirements.txt",
   "desktop_app/application_state.py",
+  "desktop_app/app_state.py",
   "desktop_app/logging_config.py",
   "desktop_app/resources/logging.yaml",
   "desktop_app/services/agent_manager.py",

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import streamlit as st
 
-from desktop_app.application_state import ApplicationState
+from desktop_app.app_state import STATE
 from desktop_app.services.agent_manager import AgentManager
 from archagents import ARCHAGENTS
 from desktop_app.services.export_service import ExportService
@@ -16,7 +16,7 @@ st.set_page_config(page_title="Caelus Agents", layout="wide")
 
 def dashboard_page():
     st.header("Dashboard")
-    st.write(ApplicationState().stats or "No stats yet")
+    st.write(STATE.stats if STATE.stats else "No stats yet")
 
 
 def exports_page():


### PR DESCRIPTION
## Summary
- add `desktop_app/app_state.py` with Qt signal-based `ApplicationState`
- show dashboard runtime stats via new `STATE` instance
- track new file in `expected_files.json`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ce5bc538c832fa1b36e72385d3803