### PR TITLE
Add Seraph LLM prototype

### DIFF
--- a/adeptus_docs/constitution/us_constitution.txt
+++ b/adeptus_docs/constitution/us_constitution.txt
@@ -1,0 +1,1 @@
+We the People of the United States, in Order to form a more perfect Union, establish Justice, insure domestic Tranquility, provide for the common defence, promote the general Welfare, and secure the Blessings of Liberty to ourselves and our Posterity, do ordain and establish this Constitution for the United States of America.

--- a/adeptus_docs/doctrine/adeptus_foundations.md
+++ b/adeptus_docs/doctrine/adeptus_foundations.md
@@ -1,0 +1,3 @@
+# Adeptus Foundations
+
+This document contains placeholder text for the Adeptus doctrinal foundations used during ingestion.

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,7 @@
+version: '3.8'
+services:
+  seraph:
+    build: ..
+    volumes:
+      - ..:/app
+    command: /bin/bash -c "pip install -r seraph_llm/requirements.txt && python seraph_llm/chain.py"

--- a/seraph_llm/README.md
+++ b/seraph_llm/README.md
@@ -1,0 +1,45 @@
+# Seraph LLM
+
+This folder contains a minimal Retrieval-Augmented Generation (RAG) prototype. Documents
+under `../adeptus_docs` are ingested into a pgvector database and can be queried
+through a simple command line interface.
+
+## Setup
+
+1. Create a virtual environment and install dependencies:
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+
+2. Ensure PostgreSQL and Redis are running locally. Configure connection
+   information with the following environment variables as needed:
+
+   - `PG_CONNECTION` – SQLAlchemy connection string
+   - `PG_COLLECTION` – pgvector collection name
+   - `REDIS_URL` – Redis connection URL
+   - `OPENAI_API_KEY` – used for embeddings and chat completions
+
+## Usage
+
+1. Ingest the included documents:
+
+   ```bash
+   python ingestion.py
+   ```
+
+2. Start the interactive question answer loop:
+
+   ```bash
+   python chain.py
+   ```
+
+Questions may also contain JSON of the form:
+
+```json
+{"function": "call_agent", "prompt": "example"}
+```
+
+This triggers the `call_agent` function defined in `router_functions.py`.

--- a/seraph_llm/chain.py
+++ b/seraph_llm/chain.py
@@ -1,0 +1,54 @@
+"""LangChain pipeline combining retrieval and simple routing."""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from langchain.chains import RetrievalQA
+from langchain_openai import ChatOpenAI
+
+from . import memory
+from .router_functions import CALL_AGENT_SCHEMA
+
+
+def run_query(question: str) -> str:
+    """Run a query against the vector store and return the answer."""
+    store = memory.get_vectorstore()
+    chain = RetrievalQA.from_chain_type(
+        llm=ChatOpenAI(),
+        retriever=store.as_retriever(),
+    )
+    return chain.run(question)
+
+
+def call_agent(prompt: str) -> str:
+    """Simple echo agent used to demonstrate function calling."""
+    return f"Agent received: {prompt}"
+
+
+def router(question: str) -> str:
+    """Route question to agent if JSON command is detected."""
+    if question.lstrip().startswith("{"):
+        try:
+            data: Any = json.loads(question)
+        except json.JSONDecodeError:
+            return run_query(question)
+        if data.get("function") == "call_agent" and "prompt" in data:
+            return call_agent(data["prompt"])
+    return run_query(question)
+
+
+def main() -> None:
+    print("Enter a question (empty to exit):")
+    while True:
+        try:
+            q = input("? ")
+        except EOFError:
+            break
+        if not q:
+            break
+        print(router(q))
+
+
+if __name__ == "__main__":
+    main()

--- a/seraph_llm/ingestion.py
+++ b/seraph_llm/ingestion.py
@@ -1,0 +1,32 @@
+"""Ingest documents from ``../adeptus_docs`` into pgvector."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+
+from . import memory
+
+
+DOCS_DIR = Path(__file__).resolve().parent.parent / "adeptus_docs"
+
+
+def load_files() -> Iterable[str]:
+    """Yield document strings from the docs directory."""
+    for path in DOCS_DIR.rglob("*.md"):
+        yield path.read_text(encoding="utf-8")
+    for path in DOCS_DIR.rglob("*.txt"):
+        yield path.read_text(encoding="utf-8")
+
+
+def ingest() -> None:
+    """Load docs, split them, and add to vector store."""
+    splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=100)
+    for doc in load_files():
+        for chunk in splitter.split_text(doc):
+            memory.add_documents([chunk])
+
+
+if __name__ == "__main__":
+    ingest()

--- a/seraph_llm/memory.py
+++ b/seraph_llm/memory.py
@@ -1,0 +1,41 @@
+"""Utilities for working with Redis and pgvector."""
+from __future__ import annotations
+
+import os
+from typing import Iterable, List
+
+import redis
+from langchain_openai import OpenAIEmbeddings
+from langchain_community.vectorstores import PGVector
+from langchain_core.documents import Document
+
+
+_DEFAULT_CONN = "postgresql+psycopg://postgres:postgres@localhost:5432/seraph"
+_DEFAULT_COLLECTION = "seraph_docs"
+
+
+def get_redis_client() -> redis.Redis:
+    """Return a Redis client using ``REDIS_URL`` env var or default."""
+    url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+    return redis.from_url(url)
+
+
+def get_vectorstore() -> PGVector:
+    """Return a pgvector store using env vars for configuration."""
+    connection = os.getenv("PG_CONNECTION", _DEFAULT_CONN)
+    collection = os.getenv("PG_COLLECTION", _DEFAULT_COLLECTION)
+    embeddings = OpenAIEmbeddings()
+    return PGVector(connection_string=connection, collection_name=collection, embeddings=embeddings)
+
+
+def add_documents(docs: Iterable[str]) -> None:
+    """Embed and store documents in the vector store."""
+    store = get_vectorstore()
+    documents = [Document(page_content=d) for d in docs]
+    store.add_documents(documents)
+
+
+def similarity_search(query: str, k: int = 4) -> List[Document]:
+    """Search the vector store for similar documents."""
+    store = get_vectorstore()
+    return store.similarity_search(query, k=k)

--- a/seraph_llm/requirements.txt
+++ b/seraph_llm/requirements.txt
@@ -1,0 +1,8 @@
+openai==1.86.0
+langchain==0.3.25
+langchain-community>=0.0.33
+langchain-openai>=0.1.6
+pgvector==0.2.4
+psycopg2-binary==2.9.10
+redis==5.0.1
+python-dotenv>=1.0

--- a/seraph_llm/router_functions.py
+++ b/seraph_llm/router_functions.py
@@ -1,0 +1,24 @@
+"""JSON schema helpers for function calling."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+CALL_AGENT_SCHEMA: Dict[str, List[Dict[str, object]]] = {
+    "functions": [
+        {
+            "name": "call_agent",
+            "description": "Invoke an external agent with a given prompt",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "prompt": {
+                        "type": "string",
+                        "description": "Prompt for the agent",
+                    }
+                },
+                "required": ["prompt"],
+            },
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- add simple docker-compose setup
- create seraph_llm module with ingestion, memory helpers and chain
- document project usage in seraph_llm/README
- include example Adeptus docs for ingestion

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dd1a24854832f85fddfa78f4675b0