### PR TITLE
Add Seraph LLM and documentation folders

### DIFF
--- a/adeptus_docs/constitution/us_constitution.txt
+++ b/adeptus_docs/constitution/us_constitution.txt
@@ -1,0 +1,5 @@
+We the People of the United States, in Order to form a more perfect Union,
+establish Justice, insure domestic Tranquility, provide for the common defence,
+promote the general Welfare, and secure the Blessings of Liberty to ourselves
+and our Posterity, do ordain and establish this Constitution for the United
+States of America.

--- a/adeptus_docs/doctrine/adeptus_foundations.md
+++ b/adeptus_docs/doctrine/adeptus_foundations.md
@@ -1,0 +1,3 @@
+# Adeptus Foundations
+
+This document outlines the core principles of the Adeptus Mechanicus.

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,24 @@
+version: '3.8'
+services:
+  app:
+    build: ..
+    command: python streamlit_app.py
+    volumes:
+      - ..:/app
+    ports:
+      - '8501:8501'
+    depends_on:
+      - postgres
+      - redis
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: caelus
+      POSTGRES_PASSWORD: caelus
+      POSTGRES_DB: caelus
+    ports:
+      - '5432:5432'
+  redis:
+    image: redis:7
+    ports:
+      - '6379:6379'

--- a/seraph_llm/chain.py
+++ b/seraph_llm/chain.py
@@ -1,0 +1,22 @@
+"""LangChain pipeline for retrieval augmented generation."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from langchain.chains import RetrievalQA
+from langchain.embeddings import OpenAIEmbeddings
+from langchain.vectorstores import FAISS
+
+from .memory import MemoryStore
+
+
+def load_chain(store: MemoryStore) -> RetrievalQA:
+    """Create a basic retrieval QA chain backed by *store*."""
+    embeddings = OpenAIEmbeddings()
+    vectorstore = FAISS.load_local(Path("faiss_store"), embeddings)
+    retriever = vectorstore.as_retriever()
+    return RetrievalQA.from_chain_type(
+        llm=None,  # placeholder for LLM
+        chain_type="stuff",
+        retriever=retriever,
+    )

--- a/seraph_llm/ingestion.py
+++ b/seraph_llm/ingestion.py
@@ -1,0 +1,12 @@
+"""Utilities for loading doctrine text into the MRI store."""
+from pathlib import Path
+
+from .memory import add_document
+
+
+def ingest_doctrine(doctrine_dir: Path) -> None:
+    """Load all doctrine files in *doctrine_dir* into MRI."""
+    for path in doctrine_dir.glob("**/*"):
+        if path.is_file():
+            text = path.read_text(encoding="utf-8")
+            add_document(text)

--- a/seraph_llm/memory.py
+++ b/seraph_llm/memory.py
@@ -1,0 +1,31 @@
+"""Helpers for working with Redis and pgvector."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import redis
+import psycopg2
+
+
+@dataclass
+class MemoryStore:
+    redis_url: str
+    pg_dsn: str
+
+    def __post_init__(self) -> None:
+        self.redis = redis.Redis.from_url(self.redis_url)
+        self.pg = psycopg2.connect(self.pg_dsn)
+
+    def add(self, text: str) -> None:
+        """Store *text* in Redis and pgvector."""
+        self.redis.rpush("documents", text)
+        cur = self.pg.cursor()
+        cur.execute("INSERT INTO documents (text) VALUES (%s)", (text,))
+        self.pg.commit()
+        cur.close()
+
+
+def add_document(text: str) -> None:
+    """Add a single document to the default store."""
+    store = MemoryStore("redis://localhost:6379/0", "dbname=caelus user=caelus")
+    store.add(text)

--- a/seraph_llm/requirements.txt
+++ b/seraph_llm/requirements.txt
@@ -1,0 +1,5 @@
+redis
+psycopg2-binary
+langchain
+openai
+faiss-cpu

--- a/seraph_llm/router_functions.py
+++ b/seraph_llm/router_functions.py
@@ -1,0 +1,14 @@
+"""JSON schema helpers for CALL_AGENT functions."""
+from __future__ import annotations
+
+from typing import Dict, Any
+
+
+CALL_AGENT_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "agent": {"type": "string"},
+        "input": {"type": "string"},
+    },
+    "required": ["agent", "input"],
+}


### PR DESCRIPTION
## Summary
- add docker compose configuration for running services
- implement new `seraph_llm` module
- add Adeptus documentation examples

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dd1a24854832f85fddfa78f4675b0