### PR TITLE
Add Docker Compose setup with local LLM service

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,13 @@ streamlit run streamlit_app.py
 
 Set the `CAELUS_LOGGING_CONFIG` environment variable to the path of a YAML file
 to override the default logging setup.
+
+## Running with Docker Compose
+
+A `docker-compose.yml` is provided to launch the LLM, Redis, and Postgres with pgvector. Start the stack with:
+
+```bash
+docker compose up
+```
+
+The LLM service listens on port `11434`, Redis on `6379`, and Postgres on `5432` with the password `vectorpass`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.7"
+services:
+  llm:
+    image: ollama/ollama:latest
+    ports: [ "11434:11434" ]
+    volumes: [ "./ollama_models:/root/.ollama" ]
+    command: ["ollama", "serve", "--model", "llama3:8b-instruct"]
+  redis:
+    image: redis:7
+    ports: [ "6379:6379" ]
+  pgvector:
+    image: ankane/pgvector
+    environment:
+      POSTGRES_PASSWORD: vectorpass
+    ports: [ "5432:5432" ]


### PR DESCRIPTION
## Summary
- add `docker-compose.yml` with services for `ollama` LLM, Redis, and pgvector-based Postgres
- document how to start the stack in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dd32402d8832fba78c1e3f9ab528a