### PR TITLE
Fix prompt router parser

### DIFF
--- a/seraph_llm/prompt_router.py
+++ b/seraph_llm/prompt_router.py
@@ -1,0 +1,35 @@
+"""Utility for parsing router outputs from agents."""
+from __future__ import annotations
+
+import json
+import re
+from typing import Union, Dict, Any
+
+SCHEMA_KEYS = {"CALL_AGENT"}
+
+
+def agent_call_schema(output: str) -> Union[str, Dict[str, Any]]:
+    """Return schema dict if *output* begins with valid JSON else raw string."""
+    cleaned = output.strip()
+    if cleaned.startswith("{"):
+        try:
+            js, _ = json.JSONDecoder().raw_decode(cleaned)
+            if isinstance(js, dict) and SCHEMA_KEYS.issubset(js.keys()):
+                sub = js["CALL_AGENT"]
+                if (
+                    isinstance(sub, dict)
+                    and {"name", "intent", "kwargs"}.issubset(sub.keys())
+                ):
+                    return js
+        except Exception:
+            pass
+    match = re.match(r"RUN:(\w+):([\w_]+)", cleaned)
+    if match:
+        return {
+            "CALL_AGENT": {
+                "name": match.group(1),
+                "intent": match.group(2),
+                "kwargs": {},
+            }
+        }
+    return output

--- a/tests/test_prompt_router.py
+++ b/tests/test_prompt_router.py
@@ -1,0 +1,22 @@
+from seraph_llm.prompt_router import agent_call_schema
+
+
+def test_parses_json_with_prefix():
+    data = {"CALL_AGENT": {"name": "foo", "intent": "bar", "kwargs": {}}}
+    text = '{"CALL_AGENT": {"name": "foo", "intent": "bar", "kwargs": {}}}'
+    assert agent_call_schema(text) == data
+
+
+def test_parses_json_with_trailing_text():
+    text = '{"CALL_AGENT": {"name": "foo", "intent": "bar", "kwargs": {}}} extra'
+    result = agent_call_schema(text)
+    assert result == {"CALL_AGENT": {"name": "foo", "intent": "bar", "kwargs": {}}}
+
+
+def test_fallback_run_syntax():
+    result = agent_call_schema('RUN:foo:bar')
+    assert result == {"CALL_AGENT": {"name": "foo", "intent": "bar", "kwargs": {}}}
+
+
+def test_returns_raw_on_invalid():
+    assert agent_call_schema('hello') == 'hello'


### PR DESCRIPTION
## Summary
- add prompt router module implementing `agent_call_schema`
- test `agent_call_schema` for JSON parsing and fallback behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dea67e008832faa486c531ac03fd9